### PR TITLE
Multi-gpu support for pytorch

### DIFF
--- a/scripts/pytorch/train.py
+++ b/scripts/pytorch/train.py
@@ -75,7 +75,7 @@ os.makedirs(model_dir, exist_ok=True)
 # device handling
 gpus = args.gpu.split(',')
 nb_gpus = len(gpus)
-device = f'cuda:{gpus[0]}'
+device = f'cuda'
 os.environ['CUDA_VISIBLE_DEVICES'] = args.gpu
 assert args.batch_size >= nb_gpus, 'Batch size (%d) should be no less than the number of gpus (%d)' % (args.batch_size, nb_gpus)
 

--- a/scripts/pytorch/train.py
+++ b/scripts/pytorch/train.py
@@ -99,6 +99,7 @@ else:
 if nb_gpus > 1:
     # use multiple GPUs via DataParallel
     model = torch.nn.DataParallel(model)
+    model.save = model.module.save
 
 # prepare the model for training and send to device
 model.train()

--- a/scripts/pytorch/train.py
+++ b/scripts/pytorch/train.py
@@ -30,7 +30,7 @@ parser.add_argument('--atlas', help='atlas filename (default: data/atlas_norm.np
 parser.add_argument('--model-dir', default='models', help='model output directory (default: models)')
 
 # training parameters
-parser.add_argument('--gpu', default='0', help='GPU ID number(s) (default: 0)')
+parser.add_argument('--gpu', default='0', help='GPU ID number(s), comma-separated (default: 0)')
 parser.add_argument('--batch-size', type=int, default=1, help='batch size (default: 1)')
 parser.add_argument('--epochs', type=int, default=1500, help='number of training epochs (default: 1500)')
 parser.add_argument('--steps-per-epoch', type=int, default=100, help='frequency of model saves (default: 100)')
@@ -73,8 +73,11 @@ model_dir = args.model_dir
 os.makedirs(model_dir, exist_ok=True)
 
 # device handling
-device = 'cuda'
+gpus = args.gpu.split(',')
+nb_gpus = len(gpus)
+device = f'cuda:{gpus[0]}'
 os.environ['CUDA_VISIBLE_DEVICES'] = args.gpu
+assert args.batch_size >= nb_gpus, 'Batch size (%d) should be no less than the number of gpus (%d)' % (args.batch_size, nb_gpus)
 
 # unet architecture
 enc_nf = args.enc if args.enc else [16, 32, 32, 32]
@@ -93,6 +96,9 @@ else:
         int_steps=args.int_steps,
         int_downsize=args.int_downsize
     )
+if nb_gpus > 1:
+    # use multiple GPUs via DataParallel
+    model = torch.nn.DataParallel(model)
 
 # prepare the model for training and send to device
 model.train()


### PR DESCRIPTION
The PR adds multi-GPUs support to the pytorch train script. This function is already present in the Tensorflow implementation, but was absen from the pytorch one.

Command-line arguments are unchanged, and in line with the Tensorflow implementation.

### New supported functions:

* Train on a single GPU, that isn't the first one. Example: command line arg "--gpu 3" trains only on Cuda device 3
* Train on any number of GPUs. Example: command line arg "--gpu 0,1" trains on GPUs No. 0 and 1. Parallelism is achieved by splitting the batch among the first dimension. If the batch size is less than the number of GPUs, an error message is thrown (behavior in-line with TensorFlow backend).

### Verification:
Implementation was verified by benchmarking training speed on synthetic data. An almost linear speedup was achieved when scaling from 1 to 4 GPUs.