### PR TITLE
Update networks.py

### DIFF
--- a/voxelmorph/torch/networks.py
+++ b/voxelmorph/torch/networks.py
@@ -63,12 +63,12 @@ class Unet(nn.Module):
         enc_history = list(reversed(self.enc_nf))
         self.uparm = nn.ModuleList()
         for i, nf in enumerate(self.dec_nf[:len(self.enc_nf)]):
-            channels = prev_nf + enc_history[i] if i > 0 else prev_nf
+            channels = prev_nf + enc_history[i-1] if i > 0 else prev_nf
             self.uparm.append(ConvBlock(ndims, channels, nf, stride=1))
             prev_nf = nf
 
         # configure extra decoder convolutions (no up-sampling)
-        prev_nf += 2
+        prev_nf += enc_history[-1]
         self.extras = nn.ModuleList()
         for nf in self.dec_nf[len(self.enc_nf):]:
             self.extras.append(ConvBlock(ndims, prev_nf, nf, stride=1))
@@ -82,7 +82,7 @@ class Unet(nn.Module):
             x_enc.append(layer(x_enc[-1]))
 
         # conv, upsample, concatenate series
-        x = x_enc.pop()
+        x = torch.clone(x_enc[-1])
         for layer in self.uparm:
             x = layer(x)
             x = self.upsample(x)


### PR DESCRIPTION
Short story:
Fix off-by-one error in the Pytorch implementation

Long story:
tedious...
The number of parameters of the original Pytorch implementation does not match those in the Tensorflow implementation.


Original Pytorch implementation
=====================================
Total num of params: 73375
unet_model.downarm.0.main.weight 360
unet_model.downarm.0.main.bias 20
unet_model.downarm.1.main.weight 3780
unet_model.downarm.1.main.bias 21
unet_model.downarm.2.main.weight 4158
unet_model.downarm.2.main.bias 22
unet_model.downarm.3.main.weight 4554
unet_model.downarm.3.main.bias 23
unet_model.uparm.0.main.weight 4968
unet_model.uparm.0.main.bias 24
unet_model.uparm.1.main.weight 10350
unet_model.uparm.1.main.bias 25
unet_model.uparm.2.main.weight 10764
unet_model.uparm.2.main.bias 26
unet_model.uparm.3.main.weight 11178
unet_model.uparm.3.main.bias 27
unet_model.extras.0.main.weight 7308
unet_model.extras.0.main.bias 28
unet_model.extras.1.main.weight 7308
unet_model.extras.1.main.bias 29
unet_model.extras.2.main.weight 7830
unet_model.extras.2.main.bias 30
flow.weight 540
flow.bias 2


Tensorflow implementation
=================================================================================================
Layer (type)                    Output Shape         Param #     Connected to                     
vxm_dense_source_input (InputLa [(None, 32, 32, 1)]  0                                            
__________________________________________________________________________________________________
vxm_dense_target_input (InputLa [(None, 32, 32, 1)]  0                                            
__________________________________________________________________________________________________
vxm_dense_unet_input_concat (Co (None, 32, 32, 2)    0           vxm_dense_source_input[0][0]     
                                                                 vxm_dense_target_input[0][0]     
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_0_0 (Co (None, 32, 32, 20)   380         vxm_dense_unet_input_concat[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_0_0_act (None, 32, 32, 20)   0           vxm_dense_unet_enc_conv_0_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_enc_pooling_0 (M (None, 16, 16, 20)   0           vxm_dense_unet_enc_conv_0_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_1_0 (Co (None, 16, 16, 21)   3801        vxm_dense_unet_enc_pooling_0[0][0
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_1_0_act (None, 16, 16, 21)   0           vxm_dense_unet_enc_conv_1_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_enc_pooling_1 (M (None, 8, 8, 21)     0           vxm_dense_unet_enc_conv_1_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_2_0 (Co (None, 8, 8, 22)     4180        vxm_dense_unet_enc_pooling_1[0][0
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_2_0_act (None, 8, 8, 22)     0           vxm_dense_unet_enc_conv_2_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_enc_pooling_2 (M (None, 4, 4, 22)     0           vxm_dense_unet_enc_conv_2_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_3_0 (Co (None, 4, 4, 23)     4577        vxm_dense_unet_enc_pooling_2[0][0
__________________________________________________________________________________________________
vxm_dense_unet_enc_conv_3_0_act (None, 4, 4, 23)     0           vxm_dense_unet_enc_conv_3_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_enc_pooling_3 (M (None, 2, 2, 23)     0           vxm_dense_unet_enc_conv_3_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_3_0 (Co (None, 2, 2, 24)     4992        vxm_dense_unet_enc_pooling_3[0][0
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_3_0_act (None, 2, 2, 24)     0           vxm_dense_unet_dec_conv_3_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_3 ( (None, 4, 4, 24)     0           vxm_dense_unet_dec_conv_3_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_3_c (None, 4, 4, 47)     0           vxm_dense_unet_dec_upsample_3[0][
                                                                 vxm_dense_unet_enc_conv_3_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_2_0 (Co (None, 4, 4, 25)     10600       vxm_dense_unet_dec_upsample_3_con
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_2_0_act (None, 4, 4, 25)     0           vxm_dense_unet_dec_conv_2_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_2 ( (None, 8, 8, 25)     0           vxm_dense_unet_dec_conv_2_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_2_c (None, 8, 8, 47)     0           vxm_dense_unet_dec_upsample_2[0][
                                                                 vxm_dense_unet_enc_conv_2_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_1_0 (Co (None, 8, 8, 26)     11024       vxm_dense_unet_dec_upsample_2_con
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_1_0_act (None, 8, 8, 26)     0           vxm_dense_unet_dec_conv_1_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_1 ( (None, 16, 16, 26)   0           vxm_dense_unet_dec_conv_1_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_1_c (None, 16, 16, 47)   0           vxm_dense_unet_dec_upsample_1[0][
                                                                 vxm_dense_unet_enc_conv_1_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_0_0 (Co (None, 16, 16, 27)   11448       vxm_dense_unet_dec_upsample_1_con
__________________________________________________________________________________________________
vxm_dense_unet_dec_conv_0_0_act (None, 16, 16, 27)   0           vxm_dense_unet_dec_conv_0_0[0][0]
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_0 ( (None, 32, 32, 27)   0           vxm_dense_unet_dec_conv_0_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_upsample_0_c (None, 32, 32, 47)   0           vxm_dense_unet_dec_upsample_0[0][
                                                                 vxm_dense_unet_enc_conv_0_0_activ
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_0 (None, 32, 32, 28)   11872       vxm_dense_unet_dec_upsample_0_con
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_0 (None, 32, 32, 28)   0           vxm_dense_unet_dec_final_conv_0[0
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_1 (None, 32, 32, 29)   7337        vxm_dense_unet_dec_final_conv_0_a
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_1 (None, 32, 32, 29)   0           vxm_dense_unet_dec_final_conv_1[0
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_2 (None, 32, 32, 30)   7860        vxm_dense_unet_dec_final_conv_1_a
__________________________________________________________________________________________________
vxm_dense_unet_dec_final_conv_2 (None, 32, 32, 30)   0           vxm_dense_unet_dec_final_conv_2[0
__________________________________________________________________________________________________
vxm_dense_flow (Conv2D)         (None, 32, 32, 2)    542         vxm_dense_unet_dec_final_conv_2_a
__________________________________________________________________________________________________
vxm_dense_transformer (SpatialT (None, 32, 32, 1)    0           vxm_dense_source_input[0][0]     
                                                                 vxm_dense_flow[0][0]             

Total params: 78,613
Trainable params: 78,613
Non-trainable params: 0



Fixed Pytorch implementation
======================================
78613
unet_model.downarm.0.main.weight 360
unet_model.downarm.0.main.bias 20
unet_model.downarm.1.main.weight 3780
unet_model.downarm.1.main.bias 21
unet_model.downarm.2.main.weight 4158
unet_model.downarm.2.main.bias 22
unet_model.downarm.3.main.weight 4554
unet_model.downarm.3.main.bias 23
unet_model.uparm.0.main.weight 4968
unet_model.uparm.0.main.bias 24
unet_model.uparm.1.main.weight 10575
unet_model.uparm.1.main.bias 25
unet_model.uparm.2.main.weight 10998
unet_model.uparm.2.main.bias 26
unet_model.uparm.3.main.weight 11421
unet_model.uparm.3.main.bias 27
unet_model.extras.0.main.weight 11844
unet_model.extras.0.main.bias 28
unet_model.extras.1.main.weight 7308
unet_model.extras.1.main.bias 29
unet_model.extras.2.main.weight 7830
unet_model.extras.2.main.bias 30
flow.weight 540
flow.bias 2

