### PR TITLE
Update License in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setuptools.setup(
     name='voxelmorph',
     version='0.1',
-    license='gpl-3.0',
+    license='Apache 2.0',
     description='Image Registration with Convolutional Networks',
     url='https://github.com/voxelmorph/voxelmorph',
     keywords=['deformation', 'registration', 'imaging', 'cnn', 'mri'],
@@ -12,7 +12,7 @@ setuptools.setup(
     classifiers=[
         'Intended Audience :: Science/Research',
         'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
     ],
     install_requires=[


### PR DESCRIPTION
The license file in the repository mentions Apache license, but in `setup.py` GPL is mentioned.
This causes GPL to appear as the license on [PyPi](https://pypi.org/project/voxelmorph/).
It seems to me that the intended license is Apache. This change aligns that.