### PR TITLE
Computing multi-channel NCC over channels individually

### DIFF
--- a/voxelmorph/tf/losses.py
+++ b/voxelmorph/tf/losses.py
@@ -34,7 +34,7 @@ class NCC:
 
         # compute filters
         in_ch = J.get_shape().as_list()[-1]
-        sum_filt = tf.ones([*self.win, in_ch, 1])
+        sum_filt = tf.ones([*self.win, 1, in_ch])
         strides = 1
         if ndims > 1:
             strides = [1] * (ndims + 2)
@@ -48,7 +48,7 @@ class NCC:
         IJ_sum = conv_fn(IJ, sum_filt, strides, padding)
 
         # compute cross correlation
-        win_size = np.prod(self.win) * in_ch
+        win_size = np.prod(self.win)
         u_I = I_sum / win_size
         u_J = J_sum / win_size
 


### PR DESCRIPTION
This should resolve #313. Thanks for the review!

While we're here, there are use-cases that weigh one modality more than others (e.g., T1 NCC weighed higher than FA NCC is common in DWI analysis). This is straightforward to add with an optional `weights` arg, but there may be some concerns with mild feature creep. Let me know if I should add it. :)