### PR TITLE
Fix license mismatch

### DIFF
--- a/voxelmorph/tf/utils/utils.py
+++ b/voxelmorph/tf/utils/utils.py
@@ -5,7 +5,17 @@ If you use this code, please cite one of the voxelmorph papers:
 https://github.com/voxelmorph/voxelmorph/blob/master/citations.bib
 
 Contact: adalca [at] csail [dot] mit [dot] edu
-License: GPLv3
+
+Copyright 2020 Adrian V. Dalca
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
 """
 
 # internal python imports
@@ -787,3 +797,4 @@ def angles_to_rotation_matrix(ang, deg=True, ndims=3):
         out = tf.matmul(rot_x, tf.matmul(rot_y, rot_z))
 
     return tf.squeeze(out) if len(shape) < 2 else out
+


### PR DESCRIPTION
Hi @adalca,

Similarly to #295, the license in `utils.py` is out of date. This PR updates that. 