### PR TITLE
N dimensional Gradient loss for pytorch

### DIFF
--- a/voxelmorph/torch/losses.py
+++ b/voxelmorph/torch/losses.py
@@ -132,4 +132,4 @@ class Grad:
         if self.loss_mult is not None:
             grad *= self.loss_mult
 
-        return torch.mean(grad)
+        return grad

--- a/voxelmorph/torch/losses.py
+++ b/voxelmorph/torch/losses.py
@@ -99,19 +99,37 @@ class Grad:
         self.penalty = penalty
         self.loss_mult = loss_mult
 
+    def _diffs(self, y):
+        vol_shape = [n for n in y.shape][2:]
+        ndims = len(vol_shape)
+
+        df = [None] * ndims
+        for i in range(ndims):
+            d = i + 2
+            # permute dimensions
+            r = [d, *range(0, d), *range(d + 1, ndims + 2)]
+            y = y.permute(r)
+            dfi = y[1:, ...] - y[:-1, ...]
+
+            # permute back
+            # note: this might not be necessary for this loss specifically,
+            # since the results are just summed over anyway.
+            r = [*range(d - 1, d + 1), *reversed(range(1, d - 1)), 0, *range(d + 1, ndims + 2)]
+            df[i] = dfi.permute(r)
+
+        return df
+
     def loss(self, _, y_pred):
-        dy = torch.abs(y_pred[:, :, 1:, :, :] - y_pred[:, :, :-1, :, :])
-        dx = torch.abs(y_pred[:, :, :, 1:, :] - y_pred[:, :, :, :-1, :])
-        dz = torch.abs(y_pred[:, :, :, :, 1:] - y_pred[:, :, :, :, :-1])
+        if self.penalty == 'l1':
+            dif = [torch.abs(f) for f in self._diffs(y_pred)]
+        else:
+            assert self.penalty == 'l2', 'penalty can only be l1 or l2. Got: %s' % self.penalty
+            dif = [f * f for f in self._diffs(y_pred)]
 
-        if self.penalty == 'l2':
-            dy = dy * dy
-            dx = dx * dx
-            dz = dz * dz
-
-        d = torch.mean(dx) + torch.mean(dy) + torch.mean(dz)
-        grad = d / 3.0
+        df = [torch.mean(torch.flatten(f, start_dim=1), dim=-1) for f in dif]
+        grad = sum(df) / len(df)
 
         if self.loss_mult is not None:
             grad *= self.loss_mult
-        return grad
+
+        return torch.mean(grad)


### PR DESCRIPTION
Hello,

I upgraded a while ago the implementation for the Gradient loss for pytorch, based on your tensorflow implementation. (Note that 'vox_weight' from tensorflow is not implemented here, when I did this is wasn't there haha).

I believe is working correctly, I've tested with some random 2D and 3D tensors and the result returned is the same from your implementation and this one. 

Tested with 'l1' and 'l2' penalties, and loss_mult.

Also I think this would solve #332.

Thanks for your time!

Kind regards