### PR TITLE
Simplify NCC loss computation (torch)

### DIFF
--- a/voxelmorph/torch/losses.py
+++ b/voxelmorph/torch/losses.py
@@ -55,12 +55,10 @@ class NCC:
         IJ_sum = conv_fn(IJ, sum_filt, stride=stride, padding=padding)
 
         win_size = np.prod(win)
-        u_I = I_sum / win_size
-        u_J = J_sum / win_size
 
-        cross = IJ_sum - u_J * I_sum - u_I * J_sum + u_I * u_J * win_size
-        I_var = I2_sum - 2 * u_I * I_sum + u_I * u_I * win_size
-        J_var = J2_sum - 2 * u_J * J_sum + u_J * u_J * win_size
+        cross = IJ_sum - I_sum * J_sum / win_size
+        I_var = I2_sum - I_sum * I_sum / win_size
+        J_var = J2_sum - J_sum * J_sum / win_size
 
         cc = cross * cross / (I_var * J_var + 1e-5)
 


### PR DESCRIPTION
Expanding out the terms, the NCC loss computational graph
can be simplified. Tested with random inputs and got
equivalent results with both implementations