### PR TITLE
add some features for torch training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 scratch/*
+*txt
+workdirs*
+*egg*

--- a/scripts/torch/train.py
+++ b/scripts/torch/train.py
@@ -77,6 +77,8 @@ parser.add_argument('--enc', type=int, nargs='+',
                     help='list of unet encoder filters (default: 16 32 32 32)')
 parser.add_argument('--dec', type=int, nargs='+',
                     help='list of unet decorder filters (default: 32 32 32 32 32 16 16)')
+parser.add_argument('--nb-conv-per-level', type=int,
+                    help='number of conv per level, (default: 1)')                    
 parser.add_argument('--int-steps', type=int, default=7,
                     help='number of integration steps (default: 7)')
 parser.add_argument('--int-downsize', type=int, default=2,
@@ -88,8 +90,9 @@ parser.add_argument('--image-loss', default='mse',
                     help='image reconstruction loss - can be mse or ncc (default: mse)')
 parser.add_argument('--lambda', type=float, dest='weight', default=0.01,
                     help='weight of deformation loss (default: 0.01)')
+parser.add_argument('--mean-std', type=float, nargs = '+', default= [0, 1],
+                    help='mean and std used to normalize the raw image')
 args = parser.parse_args()
-
 bidir = args.bidir
 
 # load and prepare training data
@@ -109,8 +112,13 @@ if args.atlas:
                                              add_feat_axis=add_feat_axis)
 else:
     # scan-to-scan generator
-    generator = vxm.generators.scan_to_scan(
-        train_files, batch_size=args.batch_size, bidir=args.bidir, add_feat_axis=add_feat_axis)
+    print('Norm param', args.mean_std)
+    generator = vxm.generators.scan_to_scan( train_files, 
+                                            batch_size=args.batch_size, 
+                                            bidir=args.bidir, 
+                                            add_feat_axis=add_feat_axis,  
+                                            mean_std = args.mean_std, 
+                                            )
 
 # extract shape from sampled input
 inshape = next(generator)[0][0].shape[1:-1]
@@ -142,11 +150,13 @@ else:
     model = vxm.networks.VxmDense(
         inshape=inshape,
         nb_unet_features=[enc_nf, dec_nf],
+        nb_unet_conv_per_level=args.nb_conv_per_level ,
         bidir=bidir,
         int_steps=args.int_steps,
         int_downsize=args.int_downsize
     )
 
+print('MODEL configuration', model)
 if nb_gpus > 1:
     # use multiple GPUs via DataParallel
     model = torch.nn.DataParallel(model)
@@ -179,6 +189,9 @@ else:
 losses += [vxm.losses.Grad('l2', loss_mult=args.int_downsize).loss]
 weights += [args.weight]
 
+num_checkpoints = 10
+save_every = args.epochs // num_checkpoints
+print('Save every', save_every)
 # training loops
 for epoch in range(args.initial_epoch, args.epochs):
 
@@ -200,15 +213,15 @@ for epoch in range(args.initial_epoch, args.epochs):
         y_true = [torch.from_numpy(d).to(device).float().permute(0, 4, 1, 2, 3) for d in y_true]
 
         # run inputs through the model to produce a warped image and flow field
-        y_pred = model(*inputs)
-
-        # calculate total loss
-        loss = 0
-        loss_list = []
-        for n, loss_function in enumerate(losses):
-            curr_loss = loss_function(y_true[n], y_pred[n]) * weights[n]
-            loss_list.append(curr_loss.item())
-            loss += curr_loss
+        with torch.cuda.amp.autocast(enabled = True):
+            y_pred = model(*inputs)
+            # calculate total loss
+            loss = 0
+            loss_list = []
+            for n, loss_function in enumerate(losses):
+                curr_loss = loss_function(y_true[n], y_pred[n]) * weights[n]
+                loss_list.append(curr_loss.item())
+                loss += curr_loss
 
         epoch_loss.append(loss_list)
         epoch_total_loss.append(loss.item())
@@ -227,6 +240,8 @@ for epoch in range(args.initial_epoch, args.epochs):
     losses_info = ', '.join(['%.4e' % f for f in np.mean(epoch_loss, axis=0)])
     loss_info = 'loss: %.4e  (%s)' % (np.mean(epoch_total_loss), losses_info)
     print(' - '.join((epoch_info, time_info, loss_info)), flush=True)
+    if epoch % save_every == 0:
+        model.save(os.path.join(model_dir, '%04d.pt' % epoch))
 
 # final model save
 model.save(os.path.join(model_dir, '%04d.pt' % args.epochs))

--- a/voxelmorph/torch/layers.py
+++ b/voxelmorph/torch/layers.py
@@ -29,7 +29,7 @@ class SpatialTransformer(nn.Module):
 
     def forward(self, src, flow):
         # new locations
-        new_locs = self.grid + flow
+        new_locs = self.grid.to(src.dtype) + flow
         shape = flow.shape[2:]
 
         # need to normalize grid values to [-1, 1] for resampler
@@ -85,13 +85,15 @@ class ResizeTransform(nn.Module):
     def forward(self, x):
         if self.factor < 1:
             # resize first to save memory
-            x = nnf.interpolate(x, align_corners=True, scale_factor=self.factor, mode=self.mode)
+            x = nnf.interpolate(x, align_corners=True, scale_factor=self.factor, mode=self.mode, 
+                                recompute_scale_factor = False)
             x = self.factor * x
 
         elif self.factor > 1:
             # multiply first to save memory
             x = self.factor * x
-            x = nnf.interpolate(x, align_corners=True, scale_factor=self.factor, mode=self.mode)
+            x = nnf.interpolate(x, align_corners=True, scale_factor=self.factor, mode=self.mode, 
+                                recompute_scale_factor = False)
 
         # don't do anything if resize is 1
         return x

--- a/voxelmorph/torch/networks.py
+++ b/voxelmorph/torch/networks.py
@@ -82,7 +82,7 @@ class Unet(nn.Module):
         # cache downsampling / upsampling operations
         MaxPooling = getattr(nn, 'MaxPool%dd' % ndims)
         self.pooling = [MaxPooling(s) for s in max_pool]
-        self.upsampling = [nn.Upsample(scale_factor=s, mode='nearest') for s in max_pool]
+        self.upsampling = [nn.Upsample(scale_factor=s, mode='trilinear', align_corners = True) for s in max_pool]
 
         # configure encoder (down-sampling path)
         prev_nf = infeats
@@ -296,10 +296,13 @@ class ConvBlock(nn.Module):
         super().__init__()
 
         Conv = getattr(nn, 'Conv%dd' % ndims)
+        Norm = getattr(nn, 'InstanceNorm%dd' %ndims)
         self.main = Conv(in_channels, out_channels, 3, stride, 1)
+        self.norm = Norm(out_channels)
         self.activation = nn.LeakyReLU(0.2)
 
     def forward(self, x):
         out = self.main(x)
+        out = self.norm(out)
         out = self.activation(out)
         return out


### PR DESCRIPTION
1. enable amp to accelerate training and reduce GPU memory footprint. 
2. add instance norm to convblock for better performance
3. add two parameters to argparse,  --nb_conv_per_level for better control of the model size, and --mean_std for normalizing data on the fly. 
4. add data flip in data generator (scan_to_scan func). 
5. adjust parameters for nn.Upsample and nnf.interpolate to remove warnings 