### PR TITLE
Optimize `affine_to_dense_shift`.

### DIFF
--- a/voxelmorph/tf/layers.py
+++ b/voxelmorph/tf/layers.py
@@ -539,14 +539,12 @@ class AffineToDenseShift(Layer):
     def build(self, input_shape):
         utils.validate_affine_shape(input_shape)
 
-    def call(self, matrix):
+    def call(self, mat):
         """
         Parameters:
-            matrix: Affine matrix of shape [B, N, N+1].
+            mat: Affine matrices of shape (B, N, N+1).
         """
-        single = lambda mat: utils.affine_to_dense_shift(mat, self.shape,
-                                                         shift_center=self.shift_center)
-        return tf.map_fn(single, matrix)
+        return utils.affine_to_dense_shift(mat, self.shape, shift_center=self.shift_center)
 
 
 class DrawAffineParams(Layer):


### PR DESCRIPTION
There is no need to: (1) multiply by one, (2) transpose after stacking, (3) stack the mesh twice, (4) use `tf.map_fn`.

<img width="451" alt="affine_to_dense_shift" src="https://github.com/voxelmorph/voxelmorph/assets/29034767/fbaca0e8-6d5e-4863-837a-dea8da476110">
