### PR TITLE
Fixed deprecated inspect.getargspec() dependency in torch/modelio.py

### DIFF
--- a/voxelmorph/torch/modelio.py
+++ b/voxelmorph/torch/modelio.py
@@ -11,7 +11,8 @@ def store_config_args(func):
     model loading - see LoadableModel.
     """
 
-    attrs, varargs, varkw, defaults = inspect.getargspec(func)
+    attrs, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations \
+        = inspect.getfullargspec(func)
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -21,6 +22,9 @@ def store_config_args(func):
         if defaults:
             for attr, val in zip(reversed(attrs), reversed(defaults)):
                 self.config[attr] = val
+
+        # add defaults from keyword arguments too
+        params.update(kwonlydefaults)
 
         # next handle positional args
         for attr, val in zip(attrs[1:], args):


### PR DESCRIPTION
Code is not yet tested. Please verify my solution.