### PR TITLE
A faster implementation of NCC using cumulative summation

### DIFF
--- a/voxelmorph/tf/losses.py
+++ b/voxelmorph/tf/losses.py
@@ -33,10 +33,162 @@ class NCC:
     Local (over window) normalized cross correlation loss.
     """
 
-    def __init__(self, win=None, eps=1e-5, signed=False):
-        self.win = win
+    def __init__(self,
+                 win=None,
+                 eps=1e-5,
+                 use_cumsum=False,
+                 signed=False,
+                 safe_cumsum=True,
+                 use_double=False,):
+
+        self.win = 9 if win is None else win
         self.eps = eps
+        self.use_cumsum = use_cumsum
         self.signed = signed
+        self.safe_cumsum = safe_cumsum
+        self.use_double = use_double
+
+    def cumsum(self, I):
+        n_dims = len(I.get_shape().as_list()) - 2
+        assert n_dims in [2, 3], "volumes should be 2 to 3 dimensions. found: %d" % n_dims
+
+        pad = self.win // 2
+
+        if n_dims == 2:
+            pad = tf.constant([
+                [0, 0],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [0, 0],
+            ])
+        else:
+            pad = tf.constant([
+                [0, 0],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [0, 0],
+            ])
+
+        I_pad = tf.pad(I, paddings=pad, mode='CONSTANT', constant_values=0)
+
+        I_cs_x = tf.cumsum(I_pad, axis=1)
+        I_cs_xy = tf.cumsum(I_cs_x, axis=2)
+
+        if n_dims == 2:
+            x, y = I.get_shape().as_list()[1:3]
+            I_win = I_cs_xy[:, self.win:, self.win:] \
+                - I_cs_xy[:, self.win:, :y] \
+                - I_cs_xy[:, :x, self.win:] \
+                + I_cs_xy[:, :x, :y]
+
+        else:
+            x, y, z = I.get_shape().as_list()[1:4]
+            I_cs_xyz = tf.cumsum(I_cs_xy, axis=3)
+            I_win = I_cs_xyz[:, self.win:, self.win:, self.win:] \
+                - I_cs_xyz[:, self.win:, self.win:, :z] \
+                - I_cs_xyz[:, self.win:, :y, self.win:] \
+                - I_cs_xyz[:, :x, self.win:, self.win:] \
+                + I_cs_xyz[:, :x, :y, self.win:] \
+                + I_cs_xyz[:, :x, self.win:, :z] \
+                + I_cs_xyz[:, self.win:, :y, :z] \
+                - I_cs_xyz[:, :x, :y, :z]
+
+        return I_win
+
+    def cumsum_safe(self, I):
+        n_dims = len(I.get_shape().as_list()) - 2
+        assert n_dims in [2, 3], "volumes should be 2 to 3 dimensions. found: %d" % n_dims
+
+        pad = self.win // 2
+
+        if n_dims == 2:
+            pad = tf.constant([
+                [0, 0],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [0, 0],
+            ])
+        else:
+            pad = tf.constant([
+                [0, 0],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [pad + 1, pad],
+                [0, 0],
+            ])
+
+        I_pad = tf.pad(I, paddings=pad, mode='CONSTANT', constant_values=0)
+        I_pad = tf.Variable(I_pad)
+
+        if n_dims == 2:
+            x, y = I.get_shape().as_list()[1:3]
+
+            I_pad[:, self.win:, :].assign(I_pad[:, self.win:, :] - I_pad[:, :x, :])
+            I_pad[:, :, self.win:].assign(I_pad[:, :, self.win:] - I_pad[:, :, :y])
+
+            I_pad = tf.cumsum(I_pad, axis=1)[:, self.win:, :]
+            I_pad = tf.cumsum(I_pad, axis=2)[:, :, self.win:]
+
+            return I_pad
+
+        else:
+            x, y, z = I.get_shape().as_list()[1:4]
+            I_pad[:, self.win:, :, :].assign(I_pad[:, self.win:, :, :] - I_pad[:, :x, :, :])
+            I_pad[:, :, self.win:, :].assign(I_pad[:, :, self.win:, :] - I_pad[:, :, :y, :])
+            I_pad[:, :, :, self.win:].assign(I_pad[:, :, :, self.win:] - I_pad[:, :, :, :z])
+
+            I_pad = tf.cumsum(I_pad, axis=1)[:, self.win:, :, :]
+            I_pad = tf.cumsum(I_pad, axis=2)[:, :, self.win:, :]
+            I_pad = tf.cumsum(I_pad, axis=3)[:, :, :, self.win:]
+
+            return I_pad
+
+    def ncc_cumsum(self, Ii, Ji):
+        ndims = len(Ii.get_shape().as_list()) - 2
+        assert ndims in [2, 3], "volumes should be 2 to 3 dimensions. found: %d" % ndims
+
+        if self.use_double:
+            Ii = tf.cast(Ii, tf.float64)
+            Ji = tf.cast(Ji, tf.float64)
+
+        # compute CC squares
+        I2 = Ii * Ii
+        J2 = Ji * Ji
+        IJ = Ii * Ji
+
+        if self.safe_cumsum:
+            I_sum = self.cumsum_safe(Ii)
+            J_sum = self.cumsum_safe(Ji)
+            I2_sum = self.cumsum_safe(I2)
+            J2_sum = self.cumsum_safe(J2)
+            IJ_sum = self.cumsum_safe(IJ)
+        else:
+            I_sum = self.cumsum(Ii)
+            J_sum = self.cumsum(Ji)
+            I2_sum = self.cumsum(I2)
+            J2_sum = self.cumsum(J2)
+            IJ_sum = self.cumsum(IJ)
+
+        # compute cross correlation
+        win_size = self.win ** ndims
+        u_I = I_sum / win_size
+        u_J = J_sum / win_size
+
+        cross = IJ_sum - u_J * I_sum - u_I * J_sum + u_I * u_J * win_size
+        cross = tf.maximum(cross, self.eps)
+        I_var = I2_sum - 2 * u_I * I_sum + u_I * u_I * win_size
+        I_var = tf.maximum(I_var, self.eps)
+        J_var = J2_sum - 2 * u_J * J_sum + u_J * u_J * win_size
+        J_var = tf.maximum(J_var, self.eps)
+
+        if self.signed:
+            cc = cross / tf.sqrt(I_var * J_var + self.eps)
+        else:
+            # cc = (cross * cross) / (I_var * J_var)
+            cc = (cross / I_var) * (cross / J_var)
+
+        return tf.cast(cc, tf.float32)
 
     def ncc(self, Ii, Ji):
         # get dimension of volume
@@ -96,8 +248,10 @@ class NCC:
         return cc
 
     def loss(self, y_true, y_pred, reduce='mean'):
-        # compute cc
-        cc = self.ncc(y_true, y_pred)
+        if self.use_cumsum:
+            cc = self.ncc_cumsum(y_true, y_pred)
+        else:
+            cc = self.ncc(y_true, y_pred)
         # reduce
         if reduce == 'mean':
             cc = tf.reduce_mean(K.batch_flatten(cc), axis=-1)
@@ -106,7 +260,7 @@ class NCC:
         elif reduce is not None:
             raise ValueError(f'Unknown NCC reduction type: {reduce}')
         # loss
-        return -cc
+        return - cc
 
 
 class MSE:

--- a/voxelmorph/torch/losses.py
+++ b/voxelmorph/torch/losses.py
@@ -9,52 +9,173 @@ class NCC:
     Local (over window) normalized cross correlation loss.
     """
 
-    def __init__(self, win=None):
-        self.win = win
+    def __init__(self,
+                 win=None,
+                 eps=1e-5,
+                 use_cumsum=False,
+                 use_double=False,
+                 safe_cumsum=True,):
+        """
+        :param win: window size for local patch. Default: 9.
+        :param eps: epsilon to avoid zero division. Default: 1e-5.
+        :param use_cumsum: whether to use cumsum for acceleration. Default: False.
+        :param use_double: whether to use double precision to prevent overflow. Default: False.
+        :param safe_cumsum: whether to use the safe cumsum implementation to prevent overflow. Default: True.
+        """
+
+        self.win = 9 if win is None else win
+        self.eps = eps
+        self.use_cumsum = use_cumsum
+        self.use_double = use_double
+        self.safe_cumsum = safe_cumsum
+
+    def cumsum(self, I):
+        """
+        Compute the sum within each sliding window using cumsum.
+        :param I: input tensor
+        :return: window-wise sum (same size as the input tensor)
+        """
+
+        # Get dimension of volume
+        n_dims = len(list(I.size())) - 2
+        assert n_dims in (2, 3), 'Input tensor has to be 2D or 3D.'
+
+        # Compute padding
+        pad = self.win // 2
+        pad = [pad + 1, pad] * n_dims
+
+        # Pad input tensor
+        I_pad = F.pad(I, pad=pad, mode='constant', value=0)
+
+        if n_dims == 3:
+            I_cs_xyz = I_pad.cumsum(2).cumsum(3).cumsum(4)
+            x, y, z = I.shape[2:]
+            I_win = I_cs_xyz[:, :, self.win:, self.win:, self.win:] \
+                - I_cs_xyz[:, :, self.win:, self.win:, :z] \
+                - I_cs_xyz[:, :, self.win:, :y, self.win:] \
+                - I_cs_xyz[:, :, :x, self.win:, self.win:] \
+                + I_cs_xyz[:, :, :x, :y, self.win:] \
+                + I_cs_xyz[:, :, :x, self.win:, :z] \
+                + I_cs_xyz[:, :, self.win:, :y, :z] \
+                - I_cs_xyz[:, :, :x, :y, :z]
+
+        else:
+            I_cs_xy = I_pad.cumsum(2).cumsum(3)
+            x, y = I.shape[2:]
+            I_win = I_cs_xy[:, :, self.win:, self.win:] \
+                - I_cs_xy[:, :, self.win:, :y] \
+                - I_cs_xy[:, :, :x, self.win:] \
+                + I_cs_xy[:, :, :x, :y]
+
+        return I_win
+
+    def cumsum_safe(self, I):
+        """
+        Compute the sum within each sliding window using cumsum.
+        :param I: input tensor
+        :return: window-wise sum (same size as the input tensor)
+        """
+
+        # Get dimension of volume
+        n_dims = len(list(I.size())) - 2
+        assert n_dims in (2, 3), 'Input tensor has to be 2D or 3D.'
+
+        # Compute padding
+        pad = self.win // 2
+        pad = [pad + 1, pad] * n_dims
+
+        # Pad input tensor
+        I_pad = F.pad(I, pad=pad, mode='constant', value=0)
+
+        if n_dims == 3:
+            x, y, z = I.shape[2:]
+            I_pad_clone = I_pad.clone()  # Cloning to prevent in-place operation
+            I_pad[:, :, self.win:, :, :] -= I_pad_clone[:, :, :x, :, :]
+            I_pad_clone = I_pad.clone()
+            I_pad[:, :, :, self.win:, :] -= I_pad_clone[:, :, :, :y, :]
+            I_pad_clone = I_pad.clone()
+            I_pad[:, :, :, :, self.win:] -= I_pad_clone[:, :, :, :, :z]
+
+            return I_pad.cumsum(2)[:, :, self.win:, :, :].cumsum(3)[:, :, :, self.win:, :].cumsum(4)[:, :, :, :, self.win:]
+
+        else:
+            x, y = I.shape[2:]
+            I_pad_clone = I_pad.clone()
+            I_pad[:, :, self.win:, :] -= I_pad_clone[:, :, :x, :]
+            I_pad_clone = I_pad.clone()
+            I_pad[:, :, :, self.win:] -= I_pad_clone[:, :, :, :y]
+
+            return I_pad.cumsum(2)[:, :, self.win:, :].cumsum(3)[:, :, :, self.win:]
+
 
     def loss(self, y_true, y_pred):
 
         Ii = y_true
         Ji = y_pred
 
-        # get dimension of volume
-        # assumes Ii, Ji are sized [batch_size, *vol_shape, nb_feats]
-        ndims = len(list(Ii.size())) - 2
-        assert ndims in [1, 2, 3], "volumes should be 1 to 3 dimensions. found: %d" % ndims
-
-        # set window size
-        win = [9] * ndims if self.win is None else self.win
-
-        # compute filters
-        sum_filt = torch.ones([1, 1, *win]).to("cuda")
-
-        pad_no = math.floor(win[0] / 2)
-
-        if ndims == 1:
-            stride = (1)
-            padding = (pad_no)
-        elif ndims == 2:
-            stride = (1, 1)
-            padding = (pad_no, pad_no)
-        else:
-            stride = (1, 1, 1)
-            padding = (pad_no, pad_no, pad_no)
-
-        # get convolution function
-        conv_fn = getattr(F, 'conv%dd' % ndims)
+        if self.use_double:
+            Ii = Ii.double()
+            Ji = Ji.double()
 
         # compute CC squares
         I2 = Ii * Ii
         J2 = Ji * Ji
         IJ = Ii * Ji
 
-        I_sum = conv_fn(Ii, sum_filt, stride=stride, padding=padding)
-        J_sum = conv_fn(Ji, sum_filt, stride=stride, padding=padding)
-        I2_sum = conv_fn(I2, sum_filt, stride=stride, padding=padding)
-        J2_sum = conv_fn(J2, sum_filt, stride=stride, padding=padding)
-        IJ_sum = conv_fn(IJ, sum_filt, stride=stride, padding=padding)
+        # get dimension of volume
+        # assumes Ii, Ji are sized [batch_size, *vol_shape, nb_feats]
+        ndims = len(list(Ii.size())) - 2
+        assert ndims in [1, 2, 3], "volumes should be 1 to 3 dimensions. found: %d" % ndims
 
-        win_size = np.prod(win)
+        if not self.use_cumsum:
+            # set window size
+            if self.win is None:
+                self.win = [9] * ndims
+            elif not isinstance(self.win, list):  # user specified a single number not a list
+                self.win = [self.win] * ndims
+
+            win_size = np.prod(self.win)
+
+            # compute filters
+            sum_filt = torch.ones([1, 1, *self.win]).to("cuda")
+
+            pad_no = math.floor(self.win[0] / 2)
+
+            if ndims == 1:
+                stride = (1)
+                padding = (pad_no)
+            elif ndims == 2:
+                stride = (1, 1)
+                padding = (pad_no, pad_no)
+            else:
+                stride = (1, 1, 1)
+                padding = (pad_no, pad_no, pad_no)
+
+            # get convolution function
+            conv_fn = getattr(F, 'conv%dd' % ndims)
+
+            I_sum = conv_fn(Ii, sum_filt, stride=stride, padding=padding)
+            J_sum = conv_fn(Ji, sum_filt, stride=stride, padding=padding)
+            I2_sum = conv_fn(I2, sum_filt, stride=stride, padding=padding)
+            J2_sum = conv_fn(J2, sum_filt, stride=stride, padding=padding)
+            IJ_sum = conv_fn(IJ, sum_filt, stride=stride, padding=padding)
+
+        else:
+            if self.safe_cumsum:
+                I_sum = self.cumsum_safe(Ii)
+                J_sum = self.cumsum_safe(Ji)
+                I2_sum = self.cumsum_safe(I2)
+                J2_sum = self.cumsum_safe(J2)
+                IJ_sum = self.cumsum_safe(IJ)
+            else:
+                I_sum = self.cumsum(Ii)
+                J_sum = self.cumsum(Ji)
+                I2_sum = self.cumsum(I2)
+                J2_sum = self.cumsum(J2)
+                IJ_sum = self.cumsum(IJ)
+
+            win_size = self.win ** ndims
+
         u_I = I_sum / win_size
         u_J = J_sum / win_size
 


### PR DESCRIPTION
Runs 14x faster using a safer approach (to prevent overflow) and 24x faster using an unsafe approach (Tensorflow implementation). Also provide the option to use double precision (to prevent overflow).

Tested on Tensorflow (2.11.0) and PyTorch (2.1.0) with both GPU (RTX 3090) and CPU (i7-8700K). Attached are the run time and accuracy on GPU:

```
----------
Tensorflow
----------
Safe cumsum impl: 0.29789113998413086 s.
Unsafe cumsum impl: 0.17483901977539062 s.
Original impl: 4.185877799987793 s.
Safe cumsum vs original: [5.820766e-10].
Unsafe cumsum vs original: [5.820766e-10].
-------
PyTorch
-------
Safe cumsum impl: 0.10962605476379395 s.
Unsafe cumsum impl: 0.03331756591796875 s.
Original impl: 1.2561259269714355 s.
Safe cumsum vs original: 2.3283064365386963e-10.
Unsafe cumsum vs original: 0.0.
````