### PR TITLE
Add utils for plotting flow, and demo of new Baker et al. color scheme

### DIFF
--- a/scripts/py/flow_utils.py
+++ b/scripts/py/flow_utils.py
@@ -1,0 +1,107 @@
+"""
+Code to convert between flow field conventions for SpatialTransformer and the
+Baker et al. colorwheel. code
+
+Note that when using a transformer, the sign of flow is the opposite of the 'offset'
+direction. That is, negative values in the x direction means the transformer samples
+from coordinates to the left of the original coordinates, which makes the image shift
+to the right (i.e. it results in a positive x-offset). When using the Baker et al.
+colorwheel, negative x values indicate a shift to the left.
+I refer to these below as 'sampling' or 'transformer' flow (for the spatialTransformer)
+ vs 'offset' or 'directional' flow (used for the colorwheel).
+
+Also note that the Voxelmorph SpatialTransformer module uses 'ij' indexing (first flow 
+dimension = vertical flow) whereas the Baker et al. colorwheel uses xy indexing
+(first flow dimension = horizontal flow)
+
+Another difference is that the flow in the PyTorch transformer assumes that the
+'flow dimension' (the axis along which the x, y, (and z) flow channels are stacked)
+is the first dimension. The colorwheel code (and the flow for the transformer
+implemented in Tensorflow)  assumes that the flow dimension is the last
+dimension.
+
+The two functions below convert between these two formats:
+    tform2dir_flow : Converts from Transformer (sampling) flow to Directional flow
+    dir2tform_flow : Converts from Directional to Transformer (sampling) flow
+
+Note that in both systems, it is more straightforward to use 'matrix' coordinates
+(i.e. (0, 0) is at the top left corner, vs cartesian coordinates origin (i.e. (0, 0) at
+bottom left corner). So when plotting, it is a good idea to make sure that the yaxis
+ is inverted (to show matrix coordinates).
+(This is the default when using matplotlib.pyplot.imshow(...))
+
+"""
+import numpy as np
+
+
+def tform2dir_flow(tform_flow: np.ndarray):
+    """
+    Transformer flow (for SpatialTransformer) has:
+        channels first (e.g. nDim, H, W, [D]) [for flow in PyTorch]
+        ij-indexing (first dimension: vertical flow. second dim: horizontal flow)
+        sampling flow (negative: shift forward. positive: shift backward)
+
+    Directional flow (for flow_to_color) has:
+        channels last (e.g. H, W, [D,] nDim)
+        xy indexing (first dimension: horizontal flow. second dim: vertical flow)
+        directional flow (positive: shift forward. negative: shift backward)
+    """
+    dir_flow = tform_flow.copy()
+
+    # 1. Reorder axes to channel-last (if necessary: if the axes are channel-last
+    # already, we can skip this step)
+    shape = tform_flow.shape
+    ndim = tform_flow.ndim
+    flow_size = ndim - 1
+    # The flow dimension should either be the first or the last dimension.
+    assert (shape[0] == flow_size) != (shape[-1] == flow_size), \
+        (f"Could not determine flow dimension. Expected the flow dimension "
+         f"(of size {flow_size}) to be the first or last dimension, but "
+         f"received input of shape {shape}")
+    if shape[0] == flow_size:
+        new_order = list(range(1, ndim)) + [0]
+        dir_flow = np.transpose(tform_flow, new_order)
+
+    # 2. Flip flow axes order (ij to xy)
+    dir_flow = np.flip(dir_flow, axis=-1).copy()
+
+    # 3. Take negative (sampling flow to directional flow)
+    dir_flow = -dir_flow
+    return dir_flow
+
+
+def dir2tform_flow(dir_flow: np.ndarray):
+    """
+    Transformer flow (for SpatialTransformer) has:
+        channels first (e.g. nDim, H, W) [for flow in PyTorch]
+        ij-indexing (first dimension: vertical flow. second dim: horizontal flow)
+        sampling flow (negative: shift forward. positive: shift backward)
+
+    Directional flow (for flow_to_color) has:
+        channels last (e.g. H, W, nDim)
+        xy indexing (first dimension: horizontal flow. second dim: vertical flow)
+        directional flow (positive: shift forward. negative: shift backward)
+    """
+    tform_flow = dir_flow.copy()
+
+    # 1. Reorder axes to channel-first (if necessary: if the axes are channel-first
+    # already, we can skip this step)
+    shape = tform_flow.shape
+    ndim = tform_flow.ndim
+    flow_size = ndim - 1
+    # The flow dimension should either be the first or the last dimension.
+    assert (shape[0] == flow_size) != (shape[-1] == flow_size), \
+        (f"Could not determine flow dimension. Expected the flow dimension "
+         f"(of size {flow_size}) to be the first or last dimension, but "
+         f"received input of shape {shape}")
+
+    if shape[-1] == flow_size:
+        new_order = [ndim - 1] + list(range(ndim - 1))  # flow channel: last to first
+        tform_flow = np.transpose(tform_flow, new_order)
+
+    # 2. Flip flow axes order (xy to ij)
+    tform_flow = np.flip(tform_flow, axis=0).copy()
+
+    # 3. Take negative (directional flow to sampling flow)
+    tform_flow = -tform_flow
+    return tform_flow

--- a/test/test_flow_coloring.py
+++ b/test/test_flow_coloring.py
@@ -1,0 +1,187 @@
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from matplotlib.colors import Normalize
+
+import neurite as ne
+from neurite.py.flow_color import flow_to_color, flow_key_map
+from scripts.py.flow_utils import tform2dir_flow, dir2tform_flow
+from voxelmorph.torch.layers import SpatialTransformer
+
+# Compare these colormap schemes
+cmaps = ['Baker', 'winter']  # use proposed Baker et al. color scheme
+
+
+
+def flow_to_color_matplotlib(X, cmap_name):
+    dy = X[:, :, 0]
+    dx = X[:, :, 1]
+    colors = np.arctan2(dy, dx)
+    colors[np.isnan(colors)] = 0
+    norm = Normalize()
+    norm.autoscale(colors)
+
+    cmap_show = matplotlib.colormaps[cmap_name]
+    flow_rgb_show = cmap_show(norm(colors))
+    return flow_rgb_show
+
+
+def matplotlib_colorwheel(cmap_name, size=100):
+    x = np.linspace(-1, 1, size)
+    dy, dx = np.meshgrid(x, x)
+    X = np.stack((dy, dx), axis=2)
+    return flow_to_color_matplotlib(X, cmap_name)
+
+
+flow_small_x = np.linspace(-1, 1, 15)
+flow_small_dx, flow_small_dy = np.meshgrid(flow_small_x, flow_small_x)
+flow_small_xy = np.stack([flow_small_dx, flow_small_dy], axis=2)
+
+
+fig1, axes1 = plt.subplots(2, 2, figsize=(5, 5))
+
+flow_wheel_big_baker = flow_key_map(100)
+flow_wheel_big_winter = matplotlib_colorwheel(cmap_name='winter', size=100)
+
+axes1[0, 0].imshow(flow_wheel_big_baker, extent=[-1, 1, 1, -1])
+axes1[0, 0].set_title('Baker et al. Colorwheel\n(RGB Image)')
+
+axes1[0, 1].imshow(flow_wheel_big_winter, extent=[-1, 1, 1, -1])
+axes1[0, 1].set_title('Winter Colorwheel\n(RGB Image)')
+
+ne.plot.flow_ax(flow_small_xy, ax=axes1[1, 0], scale=1.0, plot_block=False,
+                mode='transformer', cmap='Baker',
+                title=f'Baker et al. Colorwheel\n(arrows)',
+                axis='on')
+axes1[1, 0].set_xticks([])
+axes1[1, 0].set_yticks([])
+
+ne.plot.flow_ax(flow_small_xy, ax=axes1[1, 1], scale=1.0, plot_block=False,
+                mode='transformer', cmap='winter', title=f'Winter \n(arrows)',
+                axis='on')
+axes1[1, 1].set_xticks([])
+axes1[1, 1].set_yticks([])
+plt.tight_layout()
+a = 1
+pass
+
+
+for cmap in cmaps:
+    # ne.plot.flow_legend()
+    if cmap == 'Baker':
+        flow_wheel_big = flow_key_map(100)
+    else:
+        flow_wheel_big = matplotlib_colorwheel(cmap_name=cmap, size=100)
+
+
+    left_right_idx = 0
+    up_down_idx = 1
+
+    direction_flows_dict = {'Right (red)': {left_right_idx: 1, up_down_idx: 0},
+                            # 'Left (turquoise)': {left_right_idx: -1, up_down_idx: 0},
+                            'Up (blue)': {left_right_idx: 0, up_down_idx: -1},
+                            'Down & Left (green)': {left_right_idx: -1, up_down_idx: 1},
+                            'Left to center, Right down & right': {},  # define below
+                            'Top to middle, Bottom down': {},  # define below
+                            }
+
+    # rightward flow (should be red)
+    shape = (10, 15)
+    src = np.zeros(shape)
+    h, w = shape
+    src[h // 4 + 1:  3 * h // 4,
+        w // 4 + 1:  3 * w // 4] = 1
+
+    flow_shape = shape + (2,)
+
+    # Apply a scaling field from left to right to illustrate the effect of flows of
+    # different magnitudes
+    scaling_w = np.linspace(0.5, 1, w)
+    scaling_w = np.tile(scaling_w.reshape([1, w, 1]), (h, 1, 2))
+
+
+    def apply_transformer(tr: torch.nn.Module, x: np.ndarray, flow: np.ndarray):
+        x_tensor = torch.Tensor(x).unsqueeze(0).unsqueeze(0)
+        flow_tensor = torch.Tensor(flow).unsqueeze(0)
+        with torch.no_grad():
+            y_tensor_out = tr.forward(x_tensor, flow_tensor)
+        y_out = y_tensor_out.numpy()[0, 0]
+        return y_out
+
+
+    num_plots = len(direction_flows_dict) + 1
+    transformer = SpatialTransformer(shape)
+
+    plt_size = 3
+    fig, axes = plt.subplots(3, num_plots, figsize=(plt_size * num_plots, plt_size * 3))
+    line_ax = fig.add_axes([0.0, 0.0, 1, 1])  # [left, bottom, width, height]
+    line_ax.axvline(x=1 / num_plots + .01, color='k', linestyle='--')
+    line_ax.axis('off')
+
+    axes[0, 0].imshow(flow_wheel_big)
+    axes[0, 0].set_title('Flow Colorwheel\n(Image)')
+
+    # axes[1, 0].imshow(flow_map_small)
+    ne.plot.flow_ax(flow_small_xy, ax=axes[1, 0], scale=1.0, plot_block=False,
+                    mode='transformer', cmap=cmap, title=f'Flow Colorwheel\n(arrows)',
+                    axis='on')
+
+    axes[2, 0].imshow(src)
+    axes[2, 0].set_title('Source Image')
+
+    all_flows = []
+    half_h, half_w = shape[0] // 2, shape[1] // 2
+    for i, (name, directions_vals) in enumerate(direction_flows_dict.items()):
+        directional_flow_i = np.zeros(flow_shape)
+        max_flow_val0 = 1.5
+
+        if name == 'Top to middle, Bottom down':
+            directional_flow_i[:half_h, :half_w, left_right_idx] = max_flow_val0
+            directional_flow_i[:half_h, half_w:, left_right_idx] = -max_flow_val0
+            directional_flow_i[half_h:, :, up_down_idx] = max_flow_val0
+        elif name == 'Left to center, Right down & right':
+            directional_flow_i[:half_h, :half_w, up_down_idx] = max_flow_val0
+            directional_flow_i[half_h:, :half_w, up_down_idx] = -max_flow_val0
+            directional_flow_i[:, half_w:, left_right_idx] = max_flow_val0
+            directional_flow_i[:, half_w:, up_down_idx] = max_flow_val0
+
+        else:
+            for idx, val in directions_vals.items():
+                directional_flow_i[:, :, idx] = val * max_flow_val0
+
+        directional_flow_i = directional_flow_i * scaling_w
+
+        directional_flow_i_plot = directional_flow_i / 2
+        transformer_flow_i = dir2tform_flow(directional_flow_i)
+        all_flows.append(directional_flow_i_plot)
+
+        directional_flow_i2 = tform2dir_flow(transformer_flow_i)
+        assert np.array_equal(directional_flow_i, directional_flow_i2)
+
+        src_transformed = apply_transformer(transformer, src, transformer_flow_i)
+
+        if cmap == 'Baker':
+            flow_rgb = flow_to_color(directional_flow_i_plot)
+        else:
+            flow_rgb = flow_to_color_matplotlib(directional_flow_i_plot, cmap)
+
+        col_i = int(i) + 1
+        axes[0, col_i].imshow(flow_rgb)
+        axes[0, col_i].set_title(f'{name}\n(RGB)')
+
+        ne.plot.flow_ax(directional_flow_i_plot, ax=axes[1, col_i], scale=1.0,
+                        plot_block=False, mode='transformer', cmap=cmap,
+                        title=f'{name}\n(arrows)', axis='on')
+        axes[1, col_i].axis('scaled')
+        axes[1, col_i].set_xlim([-0.5, w - 0.5])
+        axes[1, col_i].set_ylim([h - 0.5, -0.5])
+        axes[2, col_i].imshow(src_transformed)
+        axes[2, col_i].set_title(f'Transformer output')
+
+    plt.suptitle(f'Flow fields using "{cmap}" color scheme', fontsize=20)
+    plt.tight_layout()
+
+    plt.show(block=False)
+
+print('Done!')


### PR DESCRIPTION
Use the test/test_flow_coloring.py script to see a comparison of the new Baker et al. flow color scheme.
It relies on the code for the Baker et al colormap implemented in neurite in this PR: https://github.com/adalca/neurite/pull/78

Use the functions in scripts/py/flow_utils.py to convert the flow output by a transformer to the format that can be plotted with the new color scheme (tested with both PyTorch and Tensorflow)

The figures below are produced by the included test_flow_coloring.py script.

![Figure_1](https://github.com/voxelmorph/voxelmorph/assets/6079111/a97f035e-d4aa-4897-bd43-47e0484bf276)
Figure 1: Direct comparison of 'Baker et al.' color scheme and 'winter' colormap:
Some advantages of the Baker et al. color scheme are:
(a) Each direction is a distinctive color (instead of a range from blue-to-green).
(b) The color wheel is cyclic/circularly continuous as a function of direction angle (whereas there is a sharp blue/green discontinuity in the winter colormap)
(c) The 'lightness' of the color increases as the magnitude of the flow decreases, so that zero flow is white, which makes it easier to distinguish where the magnitude of the flow field is high or low.

![Figure_2](https://github.com/voxelmorph/voxelmorph/assets/6079111/45cc2cf2-9165-456a-923d-d2348d46a938)
Figure 2: Example simple flow fields plotted using the Baker et al color scheme. 
On the left column: The Flow colorwheel for this figure as an RGB image (top), as an arrow field (middle), and a test "image" -- a rectangle of 1's surrounded by 0's (bottom). Each column after this demonstrates shows a simple, spatially varying flow field, either visualized as an RGB image (top), or as an arrow field (middle). The arrow field is more straightforward to understand for smaller images like these, but becomes harder for much larger images/flow fields, where individual arrows may be hard to make out, and for which the RGB image becomes more suitable. In the RGB image, the colors at each pixel are just the color of the arrow at the corresponding location. On the bottom of each column is the output of the SpatialTransformer when applied to the test "source" image (bottom left corner) using the flow field from this column.

![Figure_3](https://github.com/voxelmorph/voxelmorph/assets/6079111/af84ba66-8e3e-4fa7-9363-1c3e86d3f0fd)
Figure 3: Example simple flow fields plotted using the Winter et al color scheme.  Same as Figure 2, but using the winter colormap. The advantages of the new Baker et al. color scheme are apparent by comparing Figures 2 and 3.
