### PR TITLE
Fix flow layer initialization: avoid direct assignment of tensors to nn.Parameter fields

### DIFF
--- a/voxelmorph/nn/models.py
+++ b/voxelmorph/nn/models.py
@@ -272,14 +272,18 @@ class VxmDeformable(nn.Module):
             flow_initializer = ne.samplers.Fixed.make(flow_initializer)
 
             # Sample the weight parameters from the distribution for first (and only) conv
-            flow_layer.conv0.weight = nn.Parameter(
-                flow_initializer(flow_layer.conv0.weight.shape)
-            ).to(self.device)
+            with torch.no_grad():
+                flow_layer.conv0.weight.copy_(
+                    flow_initializer(flow_layer.conv0.weight.shape)
+                    .to(flow_layer.conv0.weight.device)
+                )
+                if flow_layer.conv0.bias is not None:
+                    flow_layer.conv0.bias.zero_()
 
             # Set the bias term(s) to zero for the first (and only) conv
-            flow_layer.conv0.bias = nn.Parameter(
-                torch.zeros(flow_layer.conv0.bias.shape)
-            ).to(self.device)
+            if flow_layer.conv0.bias is not None:
+                with torch.no_grad():
+                    flow_layer.conv0.bias.zero_()
 
         # Register the flow layer as a submodule
         self.add_module("flow_layer", flow_layer)

--- a/voxelmorph/nn/models.py
+++ b/voxelmorph/nn/models.py
@@ -277,14 +277,10 @@ class VxmDeformable(nn.Module):
                     flow_initializer(flow_layer.conv0.weight.shape)
                     .to(flow_layer.conv0.weight.device)
                 )
+                # Set the bias term(s) to zero for the first (and only) conv
                 if flow_layer.conv0.bias is not None:
                     flow_layer.conv0.bias.zero_()
-
-            # Set the bias term(s) to zero for the first (and only) conv
-            if flow_layer.conv0.bias is not None:
-                with torch.no_grad():
-                    flow_layer.conv0.bias.zero_()
-
+                    
         # Register the flow layer as a submodule
         self.add_module("flow_layer", flow_layer)
 


### PR DESCRIPTION
# Summary
This PR fixes the initialization of the `flow_layer` weights and biases in `VxmDeformable._init_flow_layer`.

# Problem
The previous implementation assigned a new tensor directly to `flow_layer.conv0.weight` and `flow_layer.conv0.bias` using:
```python
flow_layer.conv0.weight = nn.Parameter(...)
```

This caused the following error at model construction:
`TypeError: cannot assign 'torch.cuda.FloatTensor' as parameter 'weight' (torch.nn.Parameter or None expected).`


This happens because PyTorch expects assignments to parameter fields to be of type `torch.nn.Parameter`. Direct assignment of a tensor (even wrapped in `nn.Parameter`) can break parameter registration or device placement.

# Solution
The new approach uses:

- `with torch.no_grad():`
- `.copy_()`  

to update the values of the existing parameters **in-place**, preserving their registration and device placement.

# Impact
- Fixes the `TypeError` during model initialization.  
- Ensures parameters are properly registered and on the correct device.  
- Follows PyTorch best practices for custom initialization.  

---

Please review — this should resolve the initialization error and make the model construction robust.
