### PR TITLE
[fix] ensure identity grid matches PyTorch grid_sample axis convention

### DIFF
--- a/voxelmorph/nn/modules.py
+++ b/voxelmorph/nn/modules.py
@@ -73,6 +73,13 @@ class SpatialTransformer(nn.Module):
             persistent=False  # Don't save to this module's state dict!
         )
 
+        # Ensure the identity grid's last axis is always [X, Y, (Z, ...)] order,
+        # matching PyTorch grid_sample's convention for all spatial dimensions.
+        self.identity_grid = self.identity_grid.index_select(
+            -1,
+            torch.arange(self.identity_grid.shape[-1] - 1, -1, -1, device=self.identity_grid.device)
+        )
+
     def forward(
         self,
         moving_image: torch.Tensor,

--- a/voxelmorph/nn/modules.py
+++ b/voxelmorph/nn/modules.py
@@ -67,17 +67,16 @@ class SpatialTransformer(nn.Module):
 
         # Make identity grid (the grid to later warp with deformation field) and register as a
         # buffer (without saving to `state_dict`: persistent=False)
+        identity_grid = nef.volshape_to_ndgrid(size=size, device=device)
+
+        # Fix from PR #652: ensure identity grid matches PyTorch grid_sample axis convention
+        # The last axis should be ordered as [X, Y, (Z, ...)] to match grid_sample expectations
+        identity_grid = identity_grid.flip(-1)
+
         self.register_buffer(
             name='identity_grid',
-            tensor=nef.volshape_to_ndgrid(size=size, device=device),
+            tensor=identity_grid,
             persistent=False  # Don't save to this module's state dict!
-        )
-
-        # Ensure the identity grid's last axis is always [X, Y, (Z, ...)] order,
-        # matching PyTorch grid_sample's convention for all spatial dimensions.
-        self.identity_grid = self.identity_grid.index_select(
-            -1,
-            torch.arange(self.identity_grid.shape[-1] - 1, -1, -1, device=self.identity_grid.device)
         )
 
     def forward(


### PR DESCRIPTION
## Summary
This PR updates the construction of the identity grid in `SpatialTransformer` to ensure its last axis is always ordered as **[X, Y, (Z, ...)]**, matching the convention expected by PyTorch's `grid_sample` for all spatial dimensions.

## Motivation
Previously, the identity grid was constructed in **[Y, X] (2D)** or **[Z, Y, X] (3D)** order, which does not match the **[X, Y, (Z)]** convention required by `grid_sample`.  
This mismatch could cause flipped or transposed outputs when warping images.

## Solution
After creating the identity grid, we explicitly flip the last axis to enforce the correct ordering.

## Tests
- All existing tests passed with `pytest`.  
- Manual inspection confirmed the correct orientation of warped outputs.

---

Please review and let me know if further clarification is needed!
